### PR TITLE
bind: specify version to install

### DIFF
--- a/bind/Dockerfile
+++ b/bind/Dockerfile
@@ -32,7 +32,7 @@ RUN cd /var/cache/apk-packages ; \
     done ; \
     )" ; \
     printf -- '%s\n' "${_installed}" ; \
-    [ 0 -lt "$( printf -- '%s\n' "${_installed}" | wc -w )" ]
+    [ 1 -lt "$( printf -- '%s\n' "${_installed}" | wc -w )" ]
 
 RUN chmod -c a+rx /entrypoint.sh && \
     cp -p /etc/bind/bind.keys /var/bind/ && \

--- a/bind/Dockerfile
+++ b/bind/Dockerfile
@@ -16,9 +16,9 @@ COPY --from=builder /home/buildozer/packages /var/cache/apk-packages
 RUN printf >> /etc/apk/repositories -- \
         '%s\n' /var/cache/apk-packages/*
 
-RUN apk --update add \
+RUN _ver_mask='=~9.16' ; apk --update add \
         bash ca-certificates \
-        bind bind-plugins bind-tools bind-doc \
+        "bind${_ver_mask}" "bind-plugins${_ver_mask}" "bind-tools${_ver_mask}" "bind-doc${_ver_mask}" \
         && \
     rm -rf /var/cache/apk/*
 

--- a/dhcp/Dockerfile
+++ b/dhcp/Dockerfile
@@ -16,6 +16,18 @@ RUN apk --update add \
     : >> /var/lib/dhcp/dhcpd.leases && \
     rm -rf /var/cache/apk/*
 
+RUN cd /var/cache/apk-packages ; \
+    _installed="$( \
+    find . -name \*.apk -type f -exec basename {} .apk \; | \
+    while IFS= read -r _pkg; do \
+      __n="${_pkg%%-[0-9.]*-r[0-9]*}" ; \
+      __v="${_pkg##${__n}-}" ; \
+      apk info -e "${__n}=${__v}" ; \
+    done ; \
+    )" ; \
+    printf -- '%s\n' "${_installed}" ; \
+    [ 0 -lt "$( printf -- '%s\n' "${_installed}" | wc -w )" ]
+
 VOLUME ["/etc/dhcp"]
 
 ENTRYPOINT ["/usr/sbin/dhcpd", "-4", "-f", "-d"]


### PR DESCRIPTION
This is needed because `edge` is currently using 9.18, while we are building 9.16 versions.